### PR TITLE
Corrected JPEG-LS encoding and JPEG decoding for YBR images. Connecte…

### DIFF
--- a/DICOM.Native/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM.Native/Dicom.Imaging.Codec.Jpeg.i
@@ -462,7 +462,6 @@ void JPEGCODEC::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelDat
         if (params->ConvertColorspaceToRGB && (dinfo.out_color_space == JCS_YCbCr || dinfo.out_color_space == JCS_RGB)) { 
             if (oldPixelData->PixelRepresentation == PixelRepresentation::Signed) 
                 throw gcnew DicomCodecException("JPEG codec unable to perform colorspace conversion on signed pixel data");
-            //dinfo.jpeg_color_space = JCS_YCbCr;
             dinfo.out_color_space = JCS_RGB;
             newPixelData->PhotometricInterpretation = PhotometricInterpretation::Rgb;
             newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;

--- a/DICOM.Native/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM.Native/Dicom.Imaging.Codec.JpegLS.cpp
@@ -63,14 +63,11 @@ namespace Dicom {
 				params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
 				params.components = oldPixelData->SamplesPerPixel;
 
-				params.ilv = CharlsInterleaveModeType::None;
+				params.ilv =
+					oldPixelData->SamplesPerPixel == 3 && oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
+					? CharlsInterleaveModeType::Sample
+					: CharlsInterleaveModeType::Line;
 				params.colorTransform = CharlsColorTransformationType::None;
-
-				if (oldPixelData->SamplesPerPixel == 3) {
-					params.ilv = (CharlsInterleaveModeType)jparams->InterleaveMode;
-					if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb)
-						params.colorTransform = (CharlsColorTransformationType)jparams->ColorTransform;
-				}
 
 				if (TransferSyntax == DicomTransferSyntax::JPEGLSNearLossless) {
 					params.allowedlossyerror = jparams->AllowedError;

--- a/DICOM.Native/Windows/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM.Native/Windows/Dicom.Imaging.Codec.Jpeg.i
@@ -470,7 +470,6 @@ void JPEGCODEC::Decode(NativePixelData^ oldPixelData, NativePixelData^ newPixelD
         if (params->ConvertColorspaceToRGB && (dinfo.out_color_space == JCS_YCbCr || dinfo.out_color_space == JCS_RGB)) { 
             if (oldPixelData->PixelRepresentation == PixelRepresentation::Signed) 
                 throw ref new FailureException("JPEG codec unable to perform colorspace conversion on signed pixel data");
-            //dinfo.jpeg_color_space = JCS_YCbCr;
             dinfo.out_color_space = JCS_RGB;
             newPixelData->PhotometricInterpretation = PhotometricInterpretation::Rgb;
             newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;

--- a/DICOM.Native/Windows/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM.Native/Windows/Dicom.Imaging.Codec.JpegLS.cpp
@@ -52,18 +52,11 @@ void DicomJpegLsNativeCodec::Encode(NativePixelData^ oldPixelData, NativePixelDa
 	params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
 	params.components = oldPixelData->SamplesPerPixel;
 
-	params.ilv = CharlsInterleaveModeType::None;
+	params.ilv =
+		oldPixelData->SamplesPerPixel == 3 && oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
+		? CharlsInterleaveModeType::Sample
+		: CharlsInterleaveModeType::Line;
 	params.colorTransform = CharlsColorTransformationType::None;
-
-	if (oldPixelData->SamplesPerPixel == 3) {
-		params.ilv = (CharlsInterleaveModeType)jparams->InterleaveMode;
-		if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb)
-			params.colorTransform = (CharlsColorTransformationType)jparams->ColorTransform;
-	}
-
-	if (oldPixelData->TransferSyntaxIsLossy) {
-		params.allowedlossyerror = jparams->AllowedError;
-	}
 
 	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
 		Array<unsigned char>^ frameData = oldPixelData->GetFrame(frame);

--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -30,7 +30,7 @@ namespace Dicom.Imaging.Codec
         {
             InputSyntax = inputSyntax;
             OutputSyntax = outputSyntax;
-            InputCodecParams = inputCodecParams;
+            InputCodecParams = inputCodecParams ?? DefaultInputCodecParams(inputSyntax);
             OutputCodecParams = outputCodecParams;
         }
 
@@ -204,6 +204,13 @@ namespace Dicom.Imaging.Codec
             var newPixelData = DicomPixelData.Create(newDataset);
 
             return PixelDataFactory.Create(newPixelData, 0);
+        }
+
+        private static DicomCodecParams DefaultInputCodecParams(DicomTransferSyntax inputSyntax)
+        {
+            return inputSyntax == DicomTransferSyntax.JPEGProcess1 || inputSyntax == DicomTransferSyntax.JPEGProcess2_4
+                       ? new DicomJpegParams { ConvertColorspaceToRGB = true }
+                       : null;
         }
 
         private static DicomDataset Decode(


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
-
-
-

…d to #358 (#379)

* Apply pixel data properties that are not transferred during decoding. Issue #358

* Use pixel data info as input. Issue #358

Currently crash with large multiframe images and lossy JPEG-LS encoding

* Modified parameters to ensure encoding. Issue #358

* Convert to RGB when decoding JPEG P124 images. Fixes #358

* Added JPEG-LS updates to UWP source code. Issue #358